### PR TITLE
Fixed Bug - Swords Can't Attack

### DIFF
--- a/Content/Blueprints/Characters/BP_BFHChar.uasset
+++ b/Content/Blueprints/Characters/BP_BFHChar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ba99eea38869d82fdd07fe92a86b5ee6a465f4a956d3f8b5541587238de4142b
-size 520041
+oid sha256:e7188ca5132531e726c17617b735eba806f00e3a1507fde5785d237d252e46cd
+size 516657


### PR DESCRIPTION
It turns out the issue was that the Check Should Receive Attacks node had an extra pin "Target" going into it that shouldn't exist but did because refreshing pins on nodes is very finicky in Unreal.

Fix:
- Delete connections into pin
- Right Click>Refresh Node
- Connect Damage Causer pin only

Fixed :)

Broken State
![image](https://github.com/user-attachments/assets/4b394cf6-08e1-4c2c-9f76-1b848536e362)

Fixed State
![image](https://github.com/user-attachments/assets/becad12c-ad81-4852-8eb6-e5a8e5803e1f)
