### PR TITLE
Gameplay Tags Iteration 1

### DIFF
--- a/Config/DefaultGameplayTags.ini
+++ b/Config/DefaultGameplayTags.ini
@@ -1,0 +1,12 @@
+[/Script/GameplayTags.GameplayTagsSettings]
+ImportTagsFromConfig=True
+WarnOnInvalidTags=True
+ClearInvalidTags=False
+AllowEditorTagUnloading=True
+AllowGameTagUnloading=False
+FastReplication=False
+InvalidTagCharacters="\"\',"
+NumBitsForContainerSize=6
+NetIndexFirstBitSegment=16
++GameplayTagList=(Tag="BP_BFHChar.IsBFH_Char",DevComment="Whether the give actor is a BP_BPFHChar.")
+

--- a/Content/Blueprints/Characters/BP_BFHChar.uasset
+++ b/Content/Blueprints/Characters/BP_BFHChar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:63d3b98b769ff473d7258be44fa7d57de39cb0fbce0822923c55787889e1e7bc
-size 517090
+oid sha256:ca7872515ec120d82485f4cb17875fd9229d9ce731bfef63500d728180da4434
+size 548577

--- a/Content/Blueprints/Characters/BP_BFHChar.uasset
+++ b/Content/Blueprints/Characters/BP_BFHChar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:db594e177da5d0351011dc36321c1858d47091b689c5886f21a61e1ef968f67e
-size 522080
+oid sha256:63d3b98b769ff473d7258be44fa7d57de39cb0fbce0822923c55787889e1e7bc
+size 517090

--- a/Source/Team13_Game/Private/Actors/BaseGameplayTagActor.cpp
+++ b/Source/Team13_Game/Private/Actors/BaseGameplayTagActor.cpp
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "Actors/BaseGameplayTagActor.h"
+
+// Sets default values
+ABaseGameplayTagActor::ABaseGameplayTagActor()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+// Called when the game starts or when spawned
+void ABaseGameplayTagActor::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void ABaseGameplayTagActor::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}

--- a/Source/Team13_Game/Private/Actors/RhythmNoteActor.cpp
+++ b/Source/Team13_Game/Private/Actors/RhythmNoteActor.cpp
@@ -1,10 +1,10 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "RhythmNote.h"
+#include "Actors/RhythmNoteActor.h"
 
 // Sets default values
-ARhythmNote::ARhythmNote()
+ARhythmNoteActor::ARhythmNoteActor()
 {
  	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
 	PrimaryActorTick.bCanEverTick = true;
@@ -12,14 +12,14 @@ ARhythmNote::ARhythmNote()
 }
 
 // Called when the game starts or when spawned
-void ARhythmNote::BeginPlay()
+void ARhythmNoteActor::BeginPlay()
 {
 	Super::BeginPlay();
 	
 }
 
 // Called every frame
-void ARhythmNote::Tick(float DeltaTime)
+void ARhythmNoteActor::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 

--- a/Source/Team13_Game/Private/DEPRECATED_UNotePoolComponent.cpp
+++ b/Source/Team13_Game/Private/DEPRECATED_UNotePoolComponent.cpp
@@ -74,7 +74,7 @@ void UDEPRECATED_UNotePoolComponent::InitializePool(const int32& InitialSize)
 	for (int32 i = 0; i < PoolSize; i++)
 	{
 		// Initializes all the actors at the initial location of the parent.
-		TObjectPtr<ARhythmNote> NewNote = World->SpawnActor<ARhythmNote>(ARhythmNote::StaticClass(), Owner->GetActorTransform());
+		TObjectPtr<ARhythmNoteActor> NewNote = World->SpawnActor<ARhythmNoteActor>(ARhythmNoteActor::StaticClass(), Owner->GetActorTransform());
 
 		if (NewNote)
 		{
@@ -107,14 +107,14 @@ void UDEPRECATED_UNotePoolComponent::DeInitializePool()
 	UnavailableNotesInPool.Empty();
 }
 
-ARhythmNote* UDEPRECATED_UNotePoolComponent::AcquireNote(const FTransform& SpawnTransform)
+ARhythmNoteActor* UDEPRECATED_UNotePoolComponent::AcquireNote(const FTransform& SpawnTransform)
 {
 	DebugWithMessage("Acquiring New Note At" + SpawnTransform.GetLocation().ToCompactString());
 
 	if (!AvailableNotesInPool.IsEmpty())
 	{
 		auto It = AvailableNotesInPool.CreateIterator();
-		const TObjectPtr<ARhythmNote> RandomNote = *It;
+		const TObjectPtr<ARhythmNoteActor> RandomNote = *It;
 
 		// TODO: Configure actor to have a specific velocity once at spawn transform wherever this is called (likely in RhythmSubsystem).
 		if (RandomNote)
@@ -135,7 +135,7 @@ ARhythmNote* UDEPRECATED_UNotePoolComponent::AcquireNote(const FTransform& Spawn
 	return nullptr;
 }
 
-void UDEPRECATED_UNotePoolComponent::ReleaseNote(ARhythmNote* Note)
+void UDEPRECATED_UNotePoolComponent::ReleaseNote(ARhythmNoteActor* Note)
 {
 	DebugWithMessage("Releasing Note");
 

--- a/Source/Team13_Game/Private/PaperZDCharacters/BaseGameplayTagPaperZDCharacter.cpp
+++ b/Source/Team13_Game/Private/PaperZDCharacters/BaseGameplayTagPaperZDCharacter.cpp
@@ -1,0 +1,26 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "PaperZDCharacters/BaseGameplayTagPaperZDCharacter.h"
+
+// Sets default values
+ABaseGameplayTagPaperZDCharacter::ABaseGameplayTagPaperZDCharacter()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+// Called when the game starts or when spawned
+void ABaseGameplayTagPaperZDCharacter::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void ABaseGameplayTagPaperZDCharacter::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}

--- a/Source/Team13_Game/Public/Actors/BaseGameplayTagActor.h
+++ b/Source/Team13_Game/Public/Actors/BaseGameplayTagActor.h
@@ -1,0 +1,35 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagAssetInterface.h"
+#include "GameFramework/Actor.h"
+#include "BaseGameplayTagActor.generated.h"
+
+/**
+ * A C++ Actor that implements the IGameplayTagAssetInterface that is only available in C++.
+ * To be used as a way to allow Blueprint Actors to implement the IGameplayTagAssetInterface by re-parenting to this actor.
+ */
+UCLASS(Blueprintable)
+class TEAM13_GAME_API ABaseGameplayTagActor : public AActor, public IGameplayTagAssetInterface
+{
+	GENERATED_BODY()
+
+public:	
+	// Sets default values for this actor's properties
+	ABaseGameplayTagActor();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Gameplay Tags")
+	FGameplayTagContainer OwnedGameplayTags;
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+	virtual void GetOwnedGameplayTags(FGameplayTagContainer& TagContainer) const override { TagContainer = OwnedGameplayTags; };
+};

--- a/Source/Team13_Game/Public/Actors/RhythmNoteActor.h
+++ b/Source/Team13_Game/Public/Actors/RhythmNoteActor.h
@@ -4,16 +4,16 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
-#include "RhythmNote.generated.h"
+#include "RhythmNoteActor.generated.h"
 
 UCLASS(Blueprintable)
-class TEAM13_GAME_API ARhythmNote : public AActor
+class TEAM13_GAME_API ARhythmNoteActor : public AActor
 {
 	GENERATED_BODY()
 	
 public:	
 	// Sets default values for this actor's properties
-	ARhythmNote();
+	ARhythmNoteActor();
 
 protected:
 	// Called when the game starts or when spawned

--- a/Source/Team13_Game/Public/DEPRECATED_UNotePoolComponent.h
+++ b/Source/Team13_Game/Public/DEPRECATED_UNotePoolComponent.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "RhythmNote.h"
+#include "Actors/RhythmNoteActor.h"
 #include "Components/ActorComponent.h"
 #include "DEPRECATED_UNotePoolComponent.generated.h"
 
@@ -29,10 +29,10 @@ public:
 	void SetPoolSize(const int32& Size);
 
 	UFUNCTION(BlueprintCallable, Category = "Notes")
-	ARhythmNote* AcquireNote(const FTransform& SpawnTransform);
+	ARhythmNoteActor* AcquireNote(const FTransform& SpawnTransform);
 
 	UFUNCTION(BlueprintCallable, Category = "Notes")
-	void ReleaseNote(ARhythmNote* Note);
+	void ReleaseNote(ARhythmNoteActor* Note);
 
 	UFUNCTION(BlueprintCallable, Category = "Rhythm Note Pool")
 	void InitializePool(const int32& InitialSize);
@@ -55,10 +55,10 @@ public:
 private:
 
 	UPROPERTY()
-	TSet<TObjectPtr<ARhythmNote>> AvailableNotesInPool;
+	TSet<TObjectPtr<ARhythmNoteActor>> AvailableNotesInPool;
 
 	UPROPERTY()
-	TSet<TObjectPtr<ARhythmNote>> UnavailableNotesInPool;
+	TSet<TObjectPtr<ARhythmNoteActor>> UnavailableNotesInPool;
 
 	const int32 DEFAULT_POOL_SIZE = 20;
 

--- a/Source/Team13_Game/Public/PaperZDCharacters/BaseGameplayTagPaperZDCharacter.h
+++ b/Source/Team13_Game/Public/PaperZDCharacters/BaseGameplayTagPaperZDCharacter.h
@@ -1,0 +1,36 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameplayTagAssetInterface.h"
+#include "GameFramework/Actor.h"
+#include "PaperZDCharacter.h"
+#include "BaseGameplayTagPaperZDCharacter.generated.h"
+
+/**
+ * A C++ PaperZDCharacter that implements the IGameplayTagAssetInterface that is only available in C++.
+ * To be used as a way to allow Blueprint PaperZDCharacters to implement the IGameplayTagAssetInterface by re-parenting to this actor.
+ */
+UCLASS(Blueprintable)
+class TEAM13_GAME_API ABaseGameplayTagPaperZDCharacter: public APaperZDCharacter, public IGameplayTagAssetInterface
+{
+	GENERATED_BODY()
+
+public:	
+	// Sets default values for this actor's properties
+	ABaseGameplayTagPaperZDCharacter();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Gameplay Tags")
+	FGameplayTagContainer OwnedGameplayTags;
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+	virtual void GetOwnedGameplayTags(FGameplayTagContainer& TagContainer) const override { TagContainer = OwnedGameplayTags; };
+};

--- a/Source/Team13_Game/Team13_Game.Build.cs
+++ b/Source/Team13_Game/Team13_Game.Build.cs
@@ -8,7 +8,7 @@ public class Team13_Game : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "AkAudio", "AxMidiCore" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "AkAudio", "AxMidiCore", "GameplayTags" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 

--- a/Source/Team13_Game/Team13_Game.Build.cs
+++ b/Source/Team13_Game/Team13_Game.Build.cs
@@ -8,7 +8,7 @@ public class Team13_Game : ModuleRules
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
 	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "AkAudio", "AxMidiCore", "GameplayTags" });
+		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "AkAudio", "AxMidiCore", "GameplayTags", "PaperZD" });
 
 		PrivateDependencyModuleNames.AddRange(new string[] {  });
 


### PR DESCRIPTION
Created BaseGameplayTagActor and BaseGameplayTagPaperZDCharacter
A C++ Actor and PaperZDCharacter that implements the IGameplayTagAssetInterface that is only available in C++.
To be used as a way to allow Blueprint Actors and PaperZDCharacters to implement the IGameplayTagAssetInterface by re-parenting to this actor.

Re-parented BP_BFHChar to BaseGameplayTagPaperZDCharacter so that it can access gameplay tags.
Gave a IsBP_BFHChar tag to all BP_BFHChars and used efficient checking before casting on HitBox collision and SoundWave Damage.

Efficient checking involves checking if the actor implements the IGameplayTagAssetInterface, checking it it has the IsBP_BFHChar tag, and only then doing casting.